### PR TITLE
fix: github-readme-activity-graph not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 ![Solved.ac Profile](http://mazassumnida.wtf/api/v2/generate_badge?boj=fdsa200)
 
  
-![Ashutosh's github activity graph](https://github-readme-activity-graph.cyclic.app/graph?username=ChoiSangwon&theme=react)
+![Ashutosh's github activity graph](https://github-readme-activity-graph.vercel.app/graph?username=ChoiSangwon&theme=react)
 
 <!--
 **ChoiSangwon/ChoiSangwon** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.


### PR DESCRIPTION
* 해당 임베드 레포지토리의 이슈에 따라 https://github.com/Ashutosh00710/github-readme-activity-graph/issues/197 호스트 도메인을 변경했습니다.